### PR TITLE
Use chokidar for file watching; read already0compiled HTML files directl...

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2,7 +2,9 @@ var path = require("path"),
     fs = require("fs"),
     sys = require("sys"),
     exec = require('child_process').exec,
-    express = require("express");
+    express = require("express"),
+    chokidar = require("chokidar");
+    path = require("path");
 
 module.exports = function(port, filepath, command, callback){
     "use strict";
@@ -40,12 +42,21 @@ module.exports = function(port, filepath, command, callback){
 
     var lastResult;
 
-    fs.watch(filepath, function(curr, prev) {
+    var watcher = chokidar.watch(filepath, {ignored: /[\/\\]\./, persistent: true});
+    watcher.on("change", function(fpath) {
         console.log("file changed");
-        parse(function(result){
-            lastResult = result;
-            io.sockets.emit("content", lastResult);
-        });
+        if (path.extname(filepath).toLowerCase() == '.md') {
+            parse(function(result){
+                lastResult = result;
+                io.sockets.emit("content", lastResult);
+            });
+        } else {
+            fs.readFile(filepath, {encoding: "utf8"}, function(err, data) {
+                if (err) throw err;
+                lastResult = {html: data, error: ''};
+                io.sockets.emit("content", lastResult);
+            })
+        }
     });
 
     io.sockets.on("connection", function(socket){

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -44,19 +44,11 @@ module.exports = function(port, filepath, command, callback){
 
     var watcher = chokidar.watch(filepath, {ignored: /[\/\\]\./, persistent: true});
     watcher.on("change", function(fpath) {
-        console.log("file changed");
-        if (path.extname(filepath).toLowerCase() == '.md') {
-            parse(function(result){
-                lastResult = result;
-                io.sockets.emit("content", lastResult);
-            });
-        } else {
-            fs.readFile(filepath, {encoding: "utf8"}, function(err, data) {
-                if (err) throw err;
-                lastResult = {html: data, error: ''};
-                io.sockets.emit("content", lastResult);
-            })
-        }
+    console.log("file changed");
+        parse(function(result){
+            lastResult = result;
+            io.sockets.emit("content", lastResult);
+        });
     });
 
     io.sockets.on("connection", function(socket){

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -44,11 +44,7 @@ module.exports = function(port, filepath, command, callback){
 
     var watcher = chokidar.watch(filepath, {ignored: /[\/\\]\./, persistent: true});
     watcher.on("change", function(fpath) {
-<<<<<<< HEAD
         console.log("file changed");
-=======
-    console.log("file changed");
->>>>>>> bfd755b3d1c73c4d585131da14e3ca403f6b36bb
         parse(function(result){
             lastResult = result;
             io.sockets.emit("content", lastResult);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -44,7 +44,7 @@ module.exports = function(port, filepath, command, callback){
 
     var watcher = chokidar.watch(filepath, {ignored: /[\/\\]\./, persistent: true});
     watcher.on("change", function(fpath) {
-    console.log("file changed");
+        console.log("file changed");
         parse(function(result){
             lastResult = result;
             io.sockets.emit("content", lastResult);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "express": "3.x",
     "socket.io": "0.9.x",
-    "optimist": "0.6.x"
+    "optimist": "0.6.x",
+    "chokidar": "0.8.x"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This branch uses [chokidar](https://github.com/paulmillr/chokidar) as a replacment for Node's `fs.watch`, which should yield more consistent file change tracking across platforms. With `fs.watch`, only the first change to a watched file was tracked (when editing with Sublime Text on OSX 10.9). This problem is resolved when using chokidar.

I've also modified the code so that the `command` argument is only run when the tracked file has a ".md" extension (this should probably be extended to other common markdown extensions). This allows me to watch an HTML file that has been generated by another Markdown processor, such as the [knitr](http://yihui.name/knitr/) extension for R. 
