### PR TITLE
Surround filepath in quotes

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -74,7 +74,7 @@ module.exports = function(port, filepath, command, callback, projectPath){
     } else {
 
         var parse = function(callback){
-            exec(command + " < " + filepath, {
+            exec(command + " < " + '"' + filepath + '"', {
                 cwd: projectPath
             }, function(error, stdout, stderr){
                 if(error){


### PR DESCRIPTION
This should allow path with spaces to be correctly accepted by
child_process.exec().
