### PR TITLE
Serving for a directory support.

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -3,10 +3,22 @@
         scroller = markmon.scroller,
         contentDisplay = markmon.contentDisplay,
         changeHighlighter = markmon.changeHighlighter;
+    
+    if(!window.location.hash) {
+        window.location.hash = "#/";
+    } else {
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.open("GET", window.location.hash.slice(1), true);
+        xmlhttp.send();
+    }
 
     var socket = io.connect(location.origin);
     socket.on("content", function(data){
         console.log("got data");
+        if(data.path && window.location.hash.replace("#", "") !== data.path) {
+            console.log('not this page');
+            return;
+        }
         var r = contentDisplay.update(data.html);
         console.log(r);
         if(!r) return;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -20,7 +20,11 @@ module.exports = function(options, callback){
     if (projectPath) {
         projectPath = path.resolve(process.cwd(), projectPath);
     }else if (filepath) {
-        projectPath = path.dirname(filepath);
+        if(fs.lstatSync(filepath).isDirectory()) {
+            projectPath = filepath
+        } else {
+            projectPath = path.dirname(filepath);
+        }
     }
 
     if (stylesheet) {
@@ -98,6 +102,52 @@ module.exports = function(options, callback){
             });
         });
         done();
+    } else if (fs.lstatSync(filepath).isDirectory()) {
+        app.get(/.*\.md$/, function(req, res) {
+            console.log(req.path);
+            if(fs.existsSync(filepath + req.path)) {
+                parse(filepath + req.path, (function(fpath) {
+                    return function(result){
+                        lastResult = result;
+                        lastResult.path = fpath.replace(filepath, "");
+                        io.sockets.emit("content", lastResult);
+                    }; 
+                })(filepath + req.path));
+            } else {
+                console.log('file not found. ')
+            }
+            res.redirect("/#" + req.path);
+        });
+        var parse = function(fpath, callback){
+            exec(command + " < " + '"' + fpath + '"', {
+                cwd: projectPath
+            }, function(error, stdout, stderr){
+                if(error){
+                    console.log("exec error:", error);
+                } else {
+                    callback({
+                        html: stdout,
+                        error: stderr
+                    });
+                }
+            });
+        }
+        var watcher = chokidar.watch(filepath, {ignored: /[\/\\]\./, persistent: true});
+        watcher.on("change", function(fpath) {
+            console.log("file changed", fpath);
+            parse(fpath, (function(fpath) {
+                return function(result){
+                    lastResult = result;
+                    lastResult.path = fpath.replace(filepath, "");
+                    io.sockets.emit("content", lastResult);
+                }; 
+            })(fpath));
+        });
+        parse(filepath + "/index.md", function(result){
+            lastResult = result;
+            lastResult.path = "/";
+            done();
+        });
     } else {
 
         var parse = function(callback){


### PR DESCRIPTION
Hi I have added the feature I requested yesterday(https://github.com/yyjhao/markmon/issues/14), with some tricky ways. You can run `markmon ./` to view a directory of markdown files. 

Now I can write hyperlinks in the markdown file and just click it to view what it links to. That's really helpful when I'm dealing with large articles. I split it into parts, and edit them respectively. 

However there's some problem: 
- The original hash tag is replaced, so the anchors may cannot be automatically jump to. But a little additional JavaScript can fix this; 
- You have to make two request to open a page, which makes it a bit slow; 
- I haven't edited the document. I don't know how; 
- I don't think it will work fine with large amount of requests and file changes. 

If you are satisfied to my pull request you can merge it. 
